### PR TITLE
docs: create assessment report for meson build system

### DIFF
--- a/meson_report.md
+++ b/meson_report.md
@@ -1,0 +1,26 @@
+# Assessment of Meson Build System Implementation
+
+## Overview
+
+This report assesses the current implementation of the Meson build system in the `beyond-rpa` project. The new build system attempts to replace a custom Python-based build script (`src/build.py`) with Meson to handle Fortran compilation, post-build tasks, and launcher script generation.
+
+## Rating: 5/10 (Incomplete Implementation)
+
+The implementation shows a solid initial effort to migrate to Meson, effectively demonstrating how to compile Fortran sources and run post-build scripts. However, it lacks essential configuration files and handles compiler flags in a brittle way.
+
+## Strengths
+* **Native Fortran Support:** Meson has excellent built-in support for Fortran, including automatic resolution of `.mod` file dependencies, which simplifies the long list of source files.
+* **Post-Build Integration:** The use of a `custom_target` combined with `.meson/scripts/post_build.py` correctly handles the copying of the binary to the `bin/` directory and generation of the `run` script, preserving existing workflows for users.
+
+## Weaknesses and Issues
+1. **Missing `meson_options.txt`:** The `src/meson.build` file attempts to read a user option `fortran_args` (`get_option('fortran_args')`). However, because there is no `meson_options.txt` (or `meson.options` in newer versions) defining this option, `meson setup` will fail immediately with an unknown option error.
+2. **Missing Preprocessing Logic:** The original `src/build.py` uses a custom preprocessing step (e.g., commenting/uncommenting sections marked with `!@CC` in `driver/driver.f90`). This step is entirely absent in the Meson build, which will break the compilation or logic of modules that rely on it (like the CC module).
+3. **Compiler Flag Handling:** The current method of manually constructing `compiler_cmd` by reading `fc.cmd_array()[0]` and concatenating `fortran_args` is non-idiomatic and brittle. Meson provides `add_project_arguments` or `fortran_args` natively in targets.
+4. **Lack of Linker Flags:** There is no handling for external libraries (like BLAS, LAPACK, or MKL), which are usually required for optimal performance in computational chemistry codes and were likely managed via the old `CompilerFlags` files.
+
+## Recommendations
+
+1. **Add `meson.options`:** Create a `meson.options` (or `meson_options.txt`) file at the project root to define `fortran_args`.
+2. **Implement Custom Preprocessing Generator:** Use Meson's `generator()` or `custom_target()` functionality to pass files through the Python preprocessor (`CodePreprocess.py`) before compiling them, exactly like `src/build.py` did.
+3. **Use Native Arguments:** Use Meson's native `add_project_arguments(..., language: 'fortran')` or pass dependencies (like OpenMP or MKL via `dependency('mkl')`) rather than manually stringing together compiler commands for the launcher. If the launcher needs the exact compiler command, consider passing `fc.cmd_array()` directly to the Python script instead of a concatenated string.
+4. **Modernize the Post-Build Step:** Instead of running a custom Python script to copy the executable to `bin/`, use Meson's native installation features (`install: true`, `install_dir: ...`). The launcher generation can still be a custom target or run script during the install phase.


### PR DESCRIPTION
This submission introduces a markdown report assessing the Meson build system implementation. It follows the user's instructions to provide a rating and recommendations, explicitly avoiding the penalization of intentionally omitted uncompiled files.

---
*PR created automatically by Jules for task [11466973944777099014](https://jules.google.com/task/11466973944777099014) started by @modrzejewski*